### PR TITLE
Add 0x prefixing/Use parity as dev chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ elixir:
 
 install:
   - sudo apt-get update
-  - sudo apt-get install nodejs npm
+  - bash travis-install.sh
   - npm install -g ganache-cli@6.1.3
   - mix local.rebar --force # for Elixir 1.3.0 and up
   - mix local.hex --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ elixir:
 
 install:
   - sudo apt-get update
-  - bash travis-install.sh
+  - bash travis_install.sh
   - npm install -g ganache-cli@6.1.3
   - mix local.rebar --force # for Elixir 1.3.0 and up
   - mix local.hex --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ elixir:
 install:
   - sudo apt-get update
   - bash travis_install.sh
-  - npm install -g ganache-cli@6.1.3
   - mix local.rebar --force # for Elixir 1.3.0 and up
   - mix local.hex --force
   - mix deps.get

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ iex(4)> simple_storage_abi = ExW3.load_abi("test/examples/build/SimpleStorage.ab
 }
 iex(5)> ExW3.Contract.start_link(SimpleStorage, abi: simple_storage_abi)
 {:ok, #PID<0.239.0>}
-iex(6)> {:ok, address} = ExW3.Contract.deploy(SimpleStorage, bin: ExW3.load_bin("test/examples/build/SimpleStorage.bin"), options: %{gas: 300000, from: Enum.at(accounts, 0)})
+iex(6)> {:ok, address} = ExW3.Contract.deploy(SimpleStorage, bin: ExW3.load_bin("test/examples/build/SimpleStorage.bin"), options: %{gas: 300_000, from: Enum.at(accounts, 0)})
 {:ok, "0xd99306b81bd61cb0ecdd3f2c946af513b3395088"}
 iex(7)> ExW3.Contract.at(SimpleStorage, address)
 :ok
 iex(8)> ExW3.Contract.call(SimpleStorage, :get)
 {:ok, 0}
-iex(9)> ExW3.Contract.send(SimpleStorage, :set, [1], %{from: Enum.at(accounts, 0)})
+iex(9)> ExW3.Contract.send(SimpleStorage, :set, [1], %{from: Enum.at(accounts, 0), gas: 50_000})
 {:ok, "0xb7e9cbdd2cec8ca017e675059a3af063d754496c960f156e1a41fe51ea82f3b8"}
 iex(10)> ExW3.Contract.call(SimpleStorage, :get)                                
 {:ok, 1}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Ensure you have an ethereum node to connect to at the specified url in your conf
 ganache-cli
 ```
 
+Or you can use parity:
+Install Parity, then run it with
+
+```
+echo > passfile
+parity --chain dev --unlock=0x00a329c0648769a73afac7f9381e08fb43dbea72 --reseal-min-period 0 --password passfile
+```
+
+If Parity complains about password or missing account, try
+
+```
+parity --chain dev --unlock=0x00a329c0648769a73afac7f9381e08fb43dbea72
+```
+
 Make sure your config includes:
 ```elixir
 config :ethereumex,

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -485,10 +485,12 @@ defmodule ExW3 do
           bin
         end
 
+      gas = ExW3.encode_data("(uint)", [args[:options][:gas]]) |> Base.encode16(case: :lower)
+
       tx = %{
         from: args[:options][:from],
-        data: constructor_arg_data,
-        gas: args[:options][:gas]
+        data: "0x#{constructor_arg_data}",
+        gas: "0x#{gas}"
       }
 
       {:ok, tx_receipt_id} = Ethereumex.HttpClient.eth_send_transaction(tx)
@@ -502,7 +504,7 @@ defmodule ExW3 do
       result =
         Ethereumex.HttpClient.eth_call(%{
           to: address,
-          data: ExW3.encode_method_call(abi, method_name, args)
+          data: "0x#{ExW3.encode_method_call(abi, method_name, args)}"
         })
 
       case result do
@@ -512,13 +514,14 @@ defmodule ExW3 do
     end
 
     def eth_send_helper(address, abi, method_name, args, options) do
+      gas = ExW3.encode_data("(uint)", [options[:gas]]) |> Base.encode16(case: :lower)
       Ethereumex.HttpClient.eth_send_transaction(
         Map.merge(
           %{
             to: address,
-            data: ExW3.encode_method_call(abi, method_name, args)
+            data: "0x#{ExW3.encode_method_call(abi, method_name, args)}"
           },
-          options
+          Map.put(options, :gas, "0x#{gas}")
         )
       )
     end

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -29,17 +29,19 @@ defmodule EXW3Test do
     assert context[:simple_storage_abi] |> is_map
   end
 
-  test "mines a block" do
-    block_number = ExW3.block_number()
-    ExW3.mine()
-    assert ExW3.block_number() == block_number + 1
-  end
+  # Only works with ganache-cli
+  
+  # test "mines a block" do
+  #   block_number = ExW3.block_number()
+  #   ExW3.mine()
+  #   assert ExW3.block_number() == block_number + 1
+  # end
 
-  test "mines multiple blocks" do
-    block_number = ExW3.block_number()
-    ExW3.mine(5)
-    assert ExW3.block_number() == block_number + 5
-  end
+  # test "mines multiple blocks" do
+  #   block_number = ExW3.block_number()
+  #   ExW3.mine(5)
+  #   assert ExW3.block_number() == block_number + 5
+  # end
 
   test "keccak256 hash some data" do
     hash = ExW3.keccak256("foo")
@@ -77,7 +79,7 @@ defmodule EXW3Test do
 
     assert data == 0
 
-    ExW3.Contract.send(SimpleStorage, :set, [1], %{from: Enum.at(context[:accounts], 0)})
+    ExW3.Contract.send(SimpleStorage, :set, [1], %{from: Enum.at(context[:accounts], 0), gas: 50_000})
 
     {:ok, data} = ExW3.Contract.call(SimpleStorage, :get)
 
@@ -131,7 +133,8 @@ defmodule EXW3Test do
 
     {:ok, tx_hash} =
       ExW3.Contract.send(EventTester, :simple, ["Hello, World!"], %{
-        from: Enum.at(context[:accounts], 0)
+            from: Enum.at(context[:accounts], 0),
+	    gas: 30_000
       })
 
     {:ok, {receipt, logs}} = ExW3.Contract.tx_receipt(EventTester, tx_hash)
@@ -173,7 +176,7 @@ defmodule EXW3Test do
 	EventTester,
 	:simple,
 	["Hello, World!"],
-	%{from: Enum.at(context[:accounts], 0)}
+	%{from: Enum.at(context[:accounts], 0), gas: 30_000}
       )
   
     receive do

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -1,0 +1,13 @@
+# just to be safe
+echo > passfile
+
+wget https://parity-downloads-mirror.parity.io/v1.8.5/x86_64-unknown-linux-gnu/parity
+
+chmod 755 ./parity
+echo > passfile
+
+./parity --chain dev 2>&1 &
+
+PARITY_PID=$!
+sleep 10
+kill -9 $(lsof -t -i:8545)

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -2,7 +2,7 @@
 #!/bin/bash
 
 # This is for travis
-parity --chain dev --unlock=0x00a329c0648769a73afac7f9381e08fb43dbea72 --reseal-min-period 0 --password passfile 2>&1 &
+./parity --chain dev --unlock=0x00a329c0648769a73afac7f9381e08fb43dbea72 --reseal-min-period 0 --password passfile 2>&1 &
 sleep 10
 mix test
 sleep 10

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -2,7 +2,7 @@
 #!/bin/bash
 
 # This is for travis
-ganache-cli 2>&1 &
+parity --chain dev --unlock=0x00a329c0648769a73afac7f9381e08fb43dbea72 --reseal-min-period 0 --password passfile 2>&1 &
 sleep 10
 mix test
 sleep 10


### PR DESCRIPTION
And they said the js blockchain had consensus breaking bugs... Turns out ganache doesn't care if you don't use 0x prefixing for data. Which was a big problem when I tried this on parity.

Big shout out to @wonjon for low key pointing this out