### PR TITLE
get_filter_changes (0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,68 +98,38 @@ ExW3 now provides async versions of `call` and `send`. They both return a `Task`
   {:ok, data} = Task.await(t)
 ```
 
-## Listening for Events
+## Events
 
-Elixir doesn't have event listeners like say JS. However, we can simulate that behavior with message passing.
-The way ExW3 handles event filters is with a background process that calls eth_getFilterChanges every cycle.
-Whenever a change is detected it will send a message to whichever process is listening.
+ExW3 allows the retrieval of event logs using filters. In this example, assume we have already deployed and registered a contract called :EventTester.
 
 ```elixir
-# Start the background listener
-ExW3.EventListener.start_link
+# We can optionally specify extra parameters like `:fromBlock`, and `:toBlock`
+{:ok, filter_id} = ExW3.Contract.filter(:EventTester, "Simple", %{fromBlock: 42, toBlock: "latest"})
 
-# Assuming we have already registered our contract called :EventTester
-# We can then add a filter for the event listener to look out for by passing in the event name, and the process we want to receive the messages when an event is triggered.
-# For now we are going to use the main process, however, we could pass in a pid of a different process.
-# We can also optionally specify extra parameters like `:fromBlock`, and `:toBlock`
-
-filter_id = ExW3.Contract.filter(:EventTester, "Simple", self(), %{fromBlock: 42, toBlock: "latest"})
-
-# We can then wait for the event. Using the typical receive keyword we wait for the first instance of the event, and then continue with the rest of the code. This is useful for testing.
-receive do
-  {:event, {filter_id, data}} -> IO.inspect data
-end
+# After some point that we think there are some new changes
+{:ok, changes} = ExW3.Contract.get_filter_changes(filter_id)
 
 # We can then uninstall the filter after we are done using it
-ExW3.uninstall_filter(filter_id)
-
-# ExW3 also provides a helper method to continuously listen for events, with the `listen` method.
-# One use is to combine all of our filters with pattern matching
-ExW3.EventListener.listen(fn result ->
-  case result do
-    {filter_id, data} -> IO.inspect data
-    {filter_id2, data} -> IO.inspect data
-  end
-end
-
-# The listen method is a simple receive loop waiting for `{:event, _}` messages.
-# It looks like this:
-def listen(callback) do
-  receive do
-    {:event, result} -> apply callback, [result]
-  end
-  listen(callback)
-end
-
-# You could do something similar with your own process, whether it is a simple Task or a more involved GenServer.
+ExW3.Contract.uninstall_filter(filter_id)
 ```
 
-## Listening for Indexed Events
+## Indexed Events
 
-Ethereum allows for filtering events specific to its parameters using indexing. For all of the options see [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter)
+Ethereum allows a user to add topics to filters. This means the filter will only return events with the specific index parameters. For all of the extra options see [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter)
 
 If you have written your event in Solidity like this:
 ```
     event SimpleIndex(uint256 indexed num, bytes32 indexed data, uint256 otherNum);
 ```
 
-You can add filter on which logs will be returned back to the RPC client, based on the indexed fields. ExW3 allows for 2 ways of specifying these parameters or `topics` in two ways. The first, and probably more preferred way, is with a map:
+You can add filter on which logs will be returned back to the RPC client, based on the indexed fields.
+
+ExW3 allows for 2 ways of specifying these parameters or `topics` in two ways. The first, and probably more preferred way, is with a map:
 
 ```elixir
   indexed_filter_id = ExW3.Contract.filter(
     :EventTester,
     "SimpleIndex",
-    self(),
     %{
       topics: %{num: 46, data: "Hello, World!"},
     }
@@ -171,7 +141,6 @@ The other option is with a list, but this is order dependent, and any values you
 ```elixir
   indexed_filter_id = ExW3.Contract.filter(
     :EventTester,
-    "SimpleIndex",
     self(),
     %{
       topics: [nil, "Hello, World!"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```elixir
 def deps do
-  [{:exw3, "~> 0.2.0"}]
+  [{:exw3, "~> 0.3.0"}]
 end
 ```
 ## Overview
@@ -161,7 +161,7 @@ def listen_for_event do
   {:ok, changes} = ExW3.Contract.get_filter_changes(filter_id) # Get our changes from the blockchain
   handle_changes(changes) # Some function to deal with the data. Good place to use pattern matching.
   :timer.sleep(1000) # Some delay in milliseconds. Recommended to save bandwidth, and not spam.
-  listen_for_event # Recurse
+  listen_for_event() # Recurse
 end
 ```
 

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -461,11 +461,11 @@ defmodule ExW3 do
       )
     end
 
-    @spec get_changes(binary(), integer()) :: {:ok, []}
-    def get_changes(filter_id, seconds \\ 0) do
+    @spec get_filter_changes(binary(), integer()) :: {:ok, []}
+    def get_filter_changes(filter_id, seconds \\ 0) do
       GenServer.call(
 	ContractManager,
-	{:get_changes, {filter_id, seconds}}
+	{:get_filter_changes, {filter_id, seconds}}
       )
     end
 
@@ -788,10 +788,10 @@ defmodule ExW3 do
 
       filter_id = ExW3.new_filter(payload)
 
-      {:reply, filter_id, Map.put(state, :filters, Map.put(state[:filters], filter_id, %{contract_name: contract_name, event_name: event_name}))}
+      {:reply, {:ok, filter_id}, Map.put(state, :filters, Map.put(state[:filters], filter_id, %{contract_name: contract_name, event_name: event_name}))}
     end
 
-    def handle_call({:get_changes, {filter_id, seconds}}, _from, state) do
+    def handle_call({:get_filter_changes, {filter_id, seconds}}, _from, state) do
 
       :timer.sleep(1000 * seconds)   
       

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -384,138 +384,6 @@ defmodule ExW3 do
     end
   end
 
-  defmodule Poller do
-    use GenServer
-
-    def start_link do
-      GenServer.start_link(__MODULE__, [], name: EventPoller)
-    end
-
-    def filter(filter_id) do
-      GenServer.cast(EventPoller, {:filter, filter_id})
-    end
-
-    @impl true
-    def init(state) do
-      # Schedule work to be performed on start
-      schedule_work()
-      {:ok, state}
-    end
-
-    @impl true
-    def handle_cast({:filter, filter_id}, state) do
-      {:noreply, [filter_id | state]}
-    end
-
-    @impl true
-    def handle_info(:work, state) do
-      # Do the desired work here
-      Enum.each(state, fn filter_id ->
-        send(Listener, {:event, filter_id, ExW3.get_filter_changes(filter_id)})
-      end)
-
-      # Reschedule once more
-      schedule_work()
-      {:noreply, state}
-    end
-
-    defp schedule_work() do
-      # In 1/2 sec
-      Process.send_after(self(), :work, 500)
-    end
-  end
-
-  defmodule EventListener do
-    def start_link do
-      Poller.start_link()
-      {:ok, pid} = Task.start_link(fn -> loop(%{}) end)
-      Process.register(pid, Listener)
-      :ok
-    end
-
-    def filter(filter_id, event_fields, pid) do
-      Poller.filter(filter_id)
-      send(Listener, {:filter, filter_id, event_fields, pid})
-    end
-
-    def listen(callback) do
-      receive do
-        {:event, result} -> apply(callback, [result])
-      end
-
-      listen(callback)
-    end
-
-    defp extract_non_indexed_fields(data, names, signature) do
-      Enum.zip(names, ExW3.decode_event(data, signature)) |> Enum.into(%{})
-    end
-
-    defp format_log_data(log, event_attributes) do
-      non_indexed_fields =
-        extract_non_indexed_fields(
-          Map.get(log, "data"),
-          event_attributes[:non_indexed_names],
-          event_attributes[:signature]
-        )
-
-      indexed_fields =
-        if length(log["topics"]) > 1 do
-          [_head | tail] = log["topics"]
-
-          decoded_topics =
-            Enum.map(0..(length(tail) - 1), fn i ->
-              topic_type = Enum.at(event_attributes[:topic_types], i)
-              topic_data = Enum.at(tail, i)
-
-              {decoded} = ExW3.decode_data(topic_type, topic_data)
-
-              decoded
-            end)
-
-          Enum.zip(event_attributes[:topic_names], decoded_topics) |> Enum.into(%{})
-        else
-          %{}
-        end
-
-      new_data = Map.merge(indexed_fields, non_indexed_fields)
-
-      Map.put(log, "data", new_data)
-    end
-
-    defp loop(state) do
-      receive do
-        {:filter, filter_id, event_attributes, pid} ->
-          loop(Map.put(state, filter_id, %{pid: pid, event_attributes: event_attributes}))
-
-        {:event, filter_id, logs} ->
-          filter_attributes = Map.get(state, filter_id)
-          event_attributes = filter_attributes[:event_attributes]
-
-          unless logs == [] do
-            Enum.each(logs, fn log ->
-              formatted_log =
-                Enum.reduce(
-                  [
-                    ExW3.keys_to_decimal(log, [
-                      "blockNumber",
-                      "logIndex",
-                      "transactionIndex",
-                      "transactionLogIndex"
-                    ]),
-                    format_log_data(log, event_attributes)
-                  ],
-                  &Map.merge/2
-                )
-
-              send(filter_attributes[:pid], {:event, {filter_id, formatted_log}})
-            end)
-          end
-
-          loop(state)
-      end
-    end
-  end
-
   defmodule Contract do
     use GenServer
 
@@ -524,7 +392,7 @@ defmodule ExW3 do
     @spec start_link() :: {:ok, pid()}
     @doc "Begins the Contract process to manage all interactions with smart contracts"
     def start_link() do
-      GenServer.start_link(__MODULE__, %{}, name: ContractManager)
+      GenServer.start_link(__MODULE__, %{filters: %{}}, name: ContractManager)
     end
 
     @spec deploy(keyword(), []) :: {:ok, binary(), []}
@@ -585,10 +453,19 @@ defmodule ExW3 do
       GenServer.call(ContractManager, {:tx_receipt, {contract_name, tx_hash}})
     end
 
-    def filter(contract_name, event_name, other_pid, event_data \\ %{}) do
+    @spec filter(keyword(), binary(), %{}) :: {:ok, binary()}
+    def filter(contract_name, event_name, event_data \\ %{}) do
       GenServer.call(
         ContractManager,
-        {:filter, {contract_name, event_name, other_pid, event_data}}
+        {:filter, {contract_name, event_name, event_data}}
+      )
+    end
+
+    @spec get_changes(binary(), integer()) :: {:ok, []}
+    def get_changes(filter_id, seconds \\ 0) do
+      GenServer.call(
+	ContractManager,
+	{:get_changes, {filter_id, seconds}}
       )
     end
 
@@ -668,7 +545,10 @@ defmodule ExW3 do
           names
         end)
 
-      [events: Enum.into(signature_types_map, %{}), event_names: Enum.into(names_map, %{})]
+      [
+	events: Enum.into(signature_types_map, %{}),
+	event_names: Enum.into(names_map, %{})
+      ]
     end
 
     # Helpers
@@ -746,9 +626,9 @@ defmodule ExW3 do
       )
     end
 
-    defp add_helper(contract_info) do
+    defp register_helper(contract_info) do
       if contract_info[:abi] do
-        contract_info ++ init_events(contract_info[:abi])
+	contract_info ++ init_events(contract_info[:abi])
       else
         raise "ABI not provided upon initialization"
       end
@@ -770,7 +650,7 @@ defmodule ExW3 do
     end
 
     def handle_cast({:register, {name, contract_info}}, state) do
-      {:noreply, Map.put(state, name, add_helper(contract_info))}
+      {:noreply, Map.put(state, name, register_helper(contract_info))}
     end
 
     # Calls
@@ -850,12 +730,49 @@ defmodule ExW3 do
       |> Map.delete(:topics)
     end
 
-    def handle_call({:filter, {contract_name, event_name, other_pid, event_data}}, _from, state) do
+    def get_event_attributes(state, contract_name, event_name) do
       contract_info = state[contract_name]
+      contract_info[:events][contract_info[:event_names][event_name]]
+    end
 
-      unless Process.whereis(Listener) do
-        raise "EventListener process not alive. Call ExW3.EventListener.start_link before using ExW3.Contract.subscribe"
-      end
+    defp extract_non_indexed_fields(data, names, signature) do
+      Enum.zip(names, ExW3.decode_event(data, signature)) |> Enum.into(%{})
+    end
+
+    defp format_log_data(log, event_attributes) do
+      non_indexed_fields =
+        extract_non_indexed_fields(
+          Map.get(log, "data"),
+          event_attributes[:non_indexed_names],
+          event_attributes[:signature]
+        )
+
+      indexed_fields =
+        if length(log["topics"]) > 1 do
+          [_head | tail] = log["topics"]
+
+          decoded_topics =
+            Enum.map(0..(length(tail) - 1), fn i ->
+              topic_type = Enum.at(event_attributes[:topic_types], i)
+              topic_data = Enum.at(tail, i)
+
+              {decoded} = ExW3.decode_data(topic_type, topic_data)
+
+              decoded
+            end)
+
+          Enum.zip(event_attributes[:topic_names], decoded_topics) |> Enum.into(%{})
+        else
+          %{}
+        end
+
+      new_data = Map.merge(indexed_fields, non_indexed_fields)
+
+      Map.put(log, "data", new_data)
+    end    
+
+    def handle_call({:filter, {contract_name, event_name, event_data}}, _from, state) do
+      contract_info = state[contract_name]
 
       event_signature = contract_info[:event_names][event_name]
       topic_types = contract_info[:events][event_signature][:topic_types]
@@ -870,11 +787,43 @@ defmodule ExW3 do
         )
 
       filter_id = ExW3.new_filter(payload)
-      event_attributes = contract_info[:events][contract_info[:event_names][event_name]]
 
-      EventListener.filter(filter_id, event_attributes, other_pid)
+      {:reply, filter_id, Map.put(state, :filters, Map.put(state[:filters], filter_id, %{contract_name: contract_name, event_name: event_name}))}
+    end
 
-      {:reply, filter_id, Map.put(state, contract_name, contract_info ++ [event_name, filter_id])}
+    def handle_call({:get_changes, {filter_id, seconds}}, _from, state) do
+
+      :timer.sleep(1000 * seconds)   
+      
+      filter_info = Map.get(state[:filters], filter_id)
+      event_attributes = get_event_attributes(state, filter_info[:contract_name], filter_info[:event_name]) 
+
+      logs = ExW3.get_filter_changes(filter_id)
+
+      formatted_logs =
+      if logs != [] do
+        Enum.map(logs, fn log ->
+	  formatted_log =
+            Enum.reduce(
+	      [
+                ExW3.keys_to_decimal(log, [
+		      "blockNumber",
+		      "logIndex",
+		      "transactionIndex",
+		      "transactionLogIndex"
+                    ]),
+                format_log_data(log, event_attributes)
+	      ],
+	      &Map.merge/2
+            )
+	  
+	  formatted_log
+        end)
+      else
+	logs
+      end
+
+      {:reply, {:ok, formatted_logs}, state}
     end
 
     def handle_call({:deploy, {name, args}}, _from, state) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -471,12 +471,12 @@ defmodule ExW3 do
       )
     end
 
-    @spec get_filter_changes(binary(), integer()) :: {:ok, []}
+    @spec get_filter_changes(binary()) :: {:ok, []}
     @doc "Using saved information related to the filter id, event logs are formatted properly"
-    def get_filter_changes(filter_id, seconds \\ 0) do
+    def get_filter_changes(filter_id) do
       GenServer.call(
 	ContractManager,
-	{:get_filter_changes, {filter_id, seconds}}
+	{:get_filter_changes, filter_id}
       )
     end
  
@@ -807,9 +807,7 @@ defmodule ExW3 do
       {:reply, {:ok, filter_id}, Map.put(state, :filters, Map.put(state[:filters], filter_id, %{contract_name: contract_name, event_name: event_name}))}
     end
 
-    def handle_call({:get_filter_changes, {filter_id, seconds}}, _from, state) do
-
-      :timer.sleep(1000 * seconds)   
+    def handle_call({:get_filter_changes, filter_id}, _from, state) do
       
       filter_info = Map.get(state[:filters], filter_id)
       event_attributes = get_event_attributes(state, filter_info[:contract_name], filter_info[:event_name]) 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExW3.MixProject do
   def project do
     [
      app: :exw3,
-     version: "0.2.0",
+     version: "0.3.0",
      elixir: "~> 1.7.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -302,7 +302,7 @@ defmodule EXW3Test do
       )
 
     # Demonstrating the delay capability
-    {:ok, change_logs} = ExW3.Contract.get_filter_changes(indexed_filter_id, 1)
+    {:ok, change_logs} = ExW3.Contract.get_filter_changes(indexed_filter_id)
 
     event_log = Enum.at(change_logs, 0)
     assert event_log |> is_map

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -186,8 +186,9 @@ defmodule EXW3Test do
   end
 
   test "Testing formatted get filter changes", context do
+    
     ExW3.Contract.register(:EventTester, abi: context[:event_tester_abi])
-
+    
     {:ok, address, _} =
       ExW3.Contract.deploy(
         :EventTester,
@@ -213,7 +214,6 @@ defmodule EXW3Test do
       )
 
     {:ok, change_logs} = ExW3.Contract.get_filter_changes(filter_id)
-
 
     event_log = Enum.at(change_logs, 0)
 

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -223,7 +223,7 @@ defmodule EXW3Test do
     assert Map.get(log_data, "num") == 42
     assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
 
-    ExW3.uninstall_filter(filter_id)
+    ExW3.Contract.uninstall_filter(filter_id)
 
     # Test indexed events
 
@@ -247,7 +247,7 @@ defmodule EXW3Test do
     assert Map.get(log_data, "num") == 46
     assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
-    ExW3.uninstall_filter(indexed_filter_id)
+    ExW3.Contract.uninstall_filter(indexed_filter_id)
 
     # Test Indexing Indexed Events
 
@@ -280,7 +280,7 @@ defmodule EXW3Test do
     assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
     
-    ExW3.uninstall_filter(indexed_filter_id)
+    ExW3.Contract.uninstall_filter(indexed_filter_id)
 
     # Tests filter with map params
 
@@ -312,7 +312,7 @@ defmodule EXW3Test do
     assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
     
-    ExW3.uninstall_filter(indexed_filter_id)
+    ExW3.Contract.uninstall_filter(indexed_filter_id)
     
   end
 

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -202,7 +202,7 @@ defmodule EXW3Test do
 
     # Test non indexed events
 
-    filter_id = ExW3.Contract.filter(:EventTester, "Simple")
+    {:ok, filter_id} = ExW3.Contract.filter(:EventTester, "Simple")
 
     {:ok, _tx_hash} =
       ExW3.Contract.send(
@@ -212,7 +212,7 @@ defmodule EXW3Test do
         %{from: Enum.at(context[:accounts], 0), gas: 30_000}
       )
 
-    {:ok, change_logs} = ExW3.Contract.get_changes(filter_id)
+    {:ok, change_logs} = ExW3.Contract.get_filter_changes(filter_id)
 
 
     event_log = Enum.at(change_logs, 0)
@@ -227,7 +227,7 @@ defmodule EXW3Test do
 
     # Test indexed events
 
-    indexed_filter_id = ExW3.Contract.filter(:EventTester, "SimpleIndex")
+    {:ok, indexed_filter_id} = ExW3.Contract.filter(:EventTester, "SimpleIndex")
 
     {:ok, _tx_hash} =
       ExW3.Contract.send(
@@ -237,7 +237,7 @@ defmodule EXW3Test do
         %{from: Enum.at(context[:accounts], 0), gas: 30_000}
       )
 
-    {:ok, change_logs} = ExW3.Contract.get_changes(indexed_filter_id)
+    {:ok, change_logs} = ExW3.Contract.get_filter_changes(indexed_filter_id)
 
     event_log = Enum.at(change_logs, 0)
     
@@ -251,7 +251,7 @@ defmodule EXW3Test do
 
     # Test Indexing Indexed Events
 
-    indexed_filter_id =
+    {:ok, indexed_filter_id} =
       ExW3.Contract.filter(
         :EventTester,
         "SimpleIndex",
@@ -270,7 +270,7 @@ defmodule EXW3Test do
         %{from: Enum.at(context[:accounts], 0), gas: 30_000}
       )
 
-    {:ok, change_logs} = ExW3.Contract.get_changes(indexed_filter_id)
+    {:ok, change_logs} = ExW3.Contract.get_filter_changes(indexed_filter_id)
 
     event_log = Enum.at(change_logs, 0)
     assert event_log |> is_map
@@ -284,7 +284,7 @@ defmodule EXW3Test do
 
     # Tests filter with map params
 
-    indexed_filter_id =
+    {:ok, indexed_filter_id} =
       ExW3.Contract.filter(
         :EventTester,
         "SimpleIndex",
@@ -302,7 +302,7 @@ defmodule EXW3Test do
       )
 
     # Demonstrating the delay capability
-    {:ok, change_logs} = ExW3.Contract.get_changes(indexed_filter_id, 1)
+    {:ok, change_logs} = ExW3.Contract.get_filter_changes(indexed_filter_id, 1)
 
     event_log = Enum.at(change_logs, 0)
     assert event_log |> is_map


### PR DESCRIPTION
Simplified the code around dealing with events. However, this is a breaking change.

Instead of EventLister, there is just `ExW3.Contract.get_filter_changes` which returns the data.