### PR TITLE
Add ExthCrypto as explicit dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule ExW3.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:ethereumex, "~> 0.4.0"},
+      {:exth_crypto, "~> 0.1.6"},
       {:abi, "~> 0.1.8"},
       {:dialyxir, "~> 1.0.0-rc.5", only: [:dev], runtime: false},
       {:poison, "~> 4.0.1"}


### PR DESCRIPTION
Without this setting up a minimal elixir project with exw3 raises warnings that a function is not available in 5 locations during "mix compile".

warning: function ExthCrypto.Hash.Keccak.kec/1 is undefined (module ExthCrypto.Hash.Keccak is not available)
Found at 5 locations:
  lib/exw3.ex:66
  lib/exw3.ex:99
  lib/exw3.ex:293
  lib/exw3.ex:389
  lib/exw3.ex:450