### PR TITLE
Fix test failures

### DIFF
--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -98,7 +98,7 @@ defmodule ExW3 do
   @spec to_checksum_address(binary()) :: binary()
   @doc "returns a checksummed address"
   def to_checksum_address(address) do
-    address = String.replace(address, ~r/^0x/, "")
+    address = address |> String.downcase() |> String.replace(~r/^0x/, "")
 
     {:ok, hash_bin} = ExKeccak.hash_256(address)
 

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -925,8 +925,7 @@ defmodule ExW3 do
                   ExW3.keys_to_decimal(log, [
                     "blockNumber",
                     "logIndex",
-                    "transactionIndex",
-                    "transactionLogIndex"
+                    "transactionIndex"
                   ]),
                   format_log_data(log, event_attributes)
                 ],

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -339,22 +339,18 @@ defmodule ExW3 do
   @spec load_abi(binary()) :: list() | {:error, atom()}
   @doc "Loads the abi at the file path and reformats it to a map"
   def load_abi(file_path) do
-    file = File.read(Path.join(File.cwd(), file_path))
-
-    case file do
-      {:ok, abi} -> reformat_abi(Jason.decode!(abi, %{}))
-      err -> err
+    with {:ok, cwd} <- File.cwd(),
+         {:ok, abi} <- File.read(Path.join([cwd, file_path])) do
+      reformat_abi(Jason.decode!(abi))
     end
   end
 
   @spec load_bin(binary()) :: binary()
   @doc "Loads the bin ar the file path"
   def load_bin(file_path) do
-    file = File.read(Path.join(File.cwd(), file_path))
-
-    case file do
-      {:ok, bin} -> bin
-      err -> err
+    with {:ok, cwd} <- File.cwd(),
+         {:ok, bin} <- File.read(Path.join([cwd, file_path])) do
+      bin
     end
   end
 

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -488,7 +488,7 @@ defmodule ExW3 do
 
     @spec start_link() :: {:ok, pid()}
     @doc "Begins the Contract process to manage all interactions with smart contracts"
-    def start_link() do
+    def start_link(_ \\ :ok) do
       GenServer.start_link(__MODULE__, %{filters: %{}}, name: ContractManager)
     end
 
@@ -747,7 +747,10 @@ defmodule ExW3 do
     # Casts
 
     def handle_cast({:at, {name, address}}, state) do
-      {:noreply, Map.put(state, name, address: address)}
+      contract_state = state[name]
+      contract_state = Keyword.put(contract_state, :address, address)
+      state = Map.put(state, name, contract_state)
+      {:noreply, state}
     end
 
     def handle_cast({:register, {name, contract_info}}, state) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -298,7 +298,7 @@ defmodule ExW3 do
   @spec encode_event(binary()) :: binary()
   @doc "Encodes event based on signature"
   def encode_event(signature) do
-    {:ok, hash} = ExKeccak.hash_256(string)
+    {:ok, hash} = ExKeccak.hash_256(signature)
 
     Base.encode16(hash, case: :lower)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ExW3.MixProject do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :ethereumex]]
+    [applications: [:logger, :ex_abi, :ethereumex]]
   end
 
   # Dependencies can be Hex packages:

--- a/test/exw3/contract_test.exs
+++ b/test/exw3/contract_test.exs
@@ -1,0 +1,59 @@
+defmodule EXW3.ContractTest do
+  use ExUnit.Case
+  doctest ExW3.Contract
+
+  @simple_storage_abi ExW3.load_abi("test/examples/build/SimpleStorage.abi")
+
+  setup_all do
+    start_supervised!(ExW3.Contract)
+    :ok
+  end
+
+  test ".at assigns the address to the state of the registered contract" do
+    ExW3.Contract.register(:SimpleStorage, abi: @simple_storage_abi)
+
+    assert ExW3.Contract.address(:SimpleStorage) == nil
+
+    accounts = ExW3.accounts()
+
+    {:ok, address, _} =
+      ExW3.Contract.deploy(
+        :SimpleStorage,
+        bin: ExW3.load_bin("test/examples/build/SimpleStorage.bin"),
+        args: [],
+        options: %{
+          gas: 300_000,
+          from: Enum.at(accounts, 0)
+        }
+      )
+
+    assert ExW3.Contract.at(:SimpleStorage, address) == :ok
+
+    state = :sys.get_state(ContractManager)
+    contract_state = state[:SimpleStorage]
+    assert Keyword.get(contract_state, :address) == address
+    assert Keyword.get(contract_state, :abi) == @simple_storage_abi
+  end
+
+  test ".address returns the registered address for the contract" do
+    ExW3.Contract.register(:SimpleStorage, abi: @simple_storage_abi)
+
+    assert ExW3.Contract.address(:SimpleStorage) == nil
+
+    accounts = ExW3.accounts()
+
+    {:ok, address, _} =
+      ExW3.Contract.deploy(
+        :SimpleStorage,
+        bin: ExW3.load_bin("test/examples/build/SimpleStorage.bin"),
+        args: [],
+        options: %{
+          gas: 300_000,
+          from: Enum.at(accounts, 0)
+        }
+      )
+
+    assert ExW3.Contract.at(:SimpleStorage, address) == :ok
+    assert ExW3.Contract.address(:SimpleStorage) == address
+  end
+end


### PR DESCRIPTION
* Fix `Contract.get_filter_changes`. There is no attribute called transactionLogIndex on an ethereum log
* Fix `Contract.at` clearing registered state
* Fix explicit load order of `ex_abi`
* Fix `load_abi` & `load_bin`
* Fix `encode_event`
* Fix `to_checksum_address`