### PR TITLE
Extract non-rpc functions into separate modules

### DIFF
--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -1,10 +1,4 @@
 defmodule ExW3 do
-  @spec to_address(binary()) :: binary()
-  @doc "Converts bytes to Ethereum address"
-  def to_address(bytes) do
-    Enum.join(["0x", bytes |> Base.encode16(case: :lower)], "")
-  end
-
   @spec accounts() :: list()
   @doc "returns all available accounts"
   def accounts do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -1,13 +1,4 @@
 defmodule ExW3 do
-  @spec format_address(binary()) :: integer()
-  @doc "Converts an Ethereum address into a form that can be used by the ABI encoder"
-  def format_address(address) do
-    address
-    |> String.slice(2..-1)
-    |> Base.decode16!(case: :lower)
-    |> :binary.decode_unsigned()
-  end
-
   @spec to_address(binary()) :: binary()
   @doc "Converts bytes to Ethereum address"
   def to_address(bytes) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -57,14 +57,6 @@ defmodule ExW3 do
     end
   end
 
-  @spec keccak256(binary()) :: binary()
-  @doc "Returns a 0x prepended 32 byte hash of the input string"
-  def keccak256(string) do
-    {:ok, hash} = ExKeccak.hash_256(string)
-
-    Enum.join(["0x", hash |> Base.encode16(case: :lower)], "")
-  end
-
   @spec bytes_to_string(binary()) :: binary()
   @doc "converts Ethereum style bytes to string"
   def bytes_to_string(bytes) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -37,16 +37,6 @@ defmodule ExW3 do
     @unit_map
   end
 
-  @spec to_wei(integer(), atom()) :: integer()
-  @doc "Converts the value to whatever unit key is provided. See unit map for details."
-  def to_wei(num, key) do
-    if @unit_map[key] do
-      num * @unit_map[key]
-    else
-      throw("#{key} not valid unit")
-    end
-  end
-
   @spec from_wei(integer(), atom()) :: integer() | float() | no_return
   @doc "Converts the value to whatever unit key is provided. See unit map for details."
   def from_wei(num, key) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -23,12 +23,6 @@ defmodule ExW3 do
     Enum.join(["0x", bytes |> Base.encode16(case: :lower)], "")
   end
 
-  @doc "checks if the address is a valid checksummed address"
-  @spec is_valid_checksum_address(binary()) :: boolean()
-  def is_valid_checksum_address(address) do
-    ExW3.Utils.to_checksum_address(address) == address
-  end
-
   @spec accounts() :: list()
   @doc "returns all available accounts"
   def accounts do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -23,40 +23,10 @@ defmodule ExW3 do
     Enum.join(["0x", bytes |> Base.encode16(case: :lower)], "")
   end
 
-  @spec to_checksum_address(binary()) :: binary()
-  @doc "returns a checksummed address"
-  def to_checksum_address(address) do
-    address = address |> String.downcase() |> String.replace(~r/^0x/, "")
-
-    {:ok, hash_bin} = ExKeccak.hash_256(address)
-
-    hash =
-      hash_bin
-      |> Base.encode16(case: :lower)
-      |> String.replace(~r/^0x/, "")
-
-    keccak_hash_list =
-      hash
-      |> String.split("", trim: true)
-      |> Enum.map(fn x -> elem(Integer.parse(x, 16), 0) end)
-
-    list_arr =
-      for n <- 0..(String.length(address) - 1) do
-        number = Enum.at(keccak_hash_list, n)
-
-        cond do
-          number >= 8 -> String.upcase(String.at(address, n))
-          true -> String.downcase(String.at(address, n))
-        end
-      end
-
-    "0x" <> List.to_string(list_arr)
-  end
-
   @doc "checks if the address is a valid checksummed address"
   @spec is_valid_checksum_address(binary()) :: boolean()
   def is_valid_checksum_address(address) do
-    to_checksum_address(address) == address
+    ExW3.Utils.to_checksum_address(address) == address
   end
 
   @spec accounts() :: list()

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -1,13 +1,4 @@
 defmodule ExW3 do
-  @spec bytes_to_string(binary()) :: binary()
-  @doc "converts Ethereum style bytes to string"
-  def bytes_to_string(bytes) do
-    bytes
-    |> Base.encode16(case: :lower)
-    |> String.replace_trailing("0", "")
-    |> Base.decode16!(case: :lower)
-  end
-
   @spec format_address(binary()) :: integer()
   @doc "Converts an Ethereum address into a form that can be used by the ABI encoder"
   def format_address(address) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -37,16 +37,6 @@ defmodule ExW3 do
     @unit_map
   end
 
-  @spec from_wei(integer(), atom()) :: integer() | float() | no_return
-  @doc "Converts the value to whatever unit key is provided. See unit map for details."
-  def from_wei(num, key) do
-    if @unit_map[key] do
-      num / @unit_map[key]
-    else
-      throw("#{key} not valid unit")
-    end
-  end
-
   @spec bytes_to_string(binary()) :: binary()
   @doc "converts Ethereum style bytes to string"
   def bytes_to_string(bytes) do

--- a/lib/exw3.ex
+++ b/lib/exw3.ex
@@ -1,42 +1,4 @@
 defmodule ExW3 do
-  Module.register_attribute(__MODULE__, :unit_map, persist: true, accumulate: false)
-
-  @unit_map %{
-    :noether => 0,
-    :wei => 1,
-    :kwei => 1_000,
-    :Kwei => 1_000,
-    :babbage => 1_000,
-    :femtoether => 1_000,
-    :mwei => 1_000_000,
-    :Mwei => 1_000_000,
-    :lovelace => 1_000_000,
-    :picoether => 1_000_000,
-    :gwei => 1_000_000_000,
-    :Gwei => 1_000_000_000,
-    :shannon => 1_000_000_000,
-    :nanoether => 1_000_000_000,
-    :nano => 1_000_000_000,
-    :szabo => 1_000_000_000_000,
-    :microether => 1_000_000_000_000,
-    :micro => 1_000_000_000_000,
-    :finney => 1_000_000_000_000_000,
-    :milliether => 1_000_000_000_000_000,
-    :milli => 1_000_000_000_000_000,
-    :ether => 1_000_000_000_000_000_000,
-    :kether => 1_000_000_000_000_000_000_000,
-    :grand => 1_000_000_000_000_000_000_000,
-    :mether => 1_000_000_000_000_000_000_000_000,
-    :gether => 1_000_000_000_000_000_000_000_000_000,
-    :tether => 1_000_000_000_000_000_000_000_000_000_000
-  }
-
-  @spec get_unit_map() :: map()
-  @doc "Returns the map used for ether unit conversion"
-  def get_unit_map do
-    @unit_map
-  end
-
   @spec bytes_to_string(binary()) :: binary()
   @doc "converts Ethereum style bytes to string"
   def bytes_to_string(bytes) do

--- a/lib/exw3/contract.ex
+++ b/lib/exw3/contract.ex
@@ -437,7 +437,7 @@ defmodule ExW3.Contract do
           formatted_log =
             Enum.reduce(
               [
-                ExW3.keys_to_decimal(log, [
+                ExW3.Normalize.transform_to_integer(log, [
                   "blockNumber",
                   "logIndex",
                   "transactionIndex"

--- a/lib/exw3/contract.ex
+++ b/lib/exw3/contract.ex
@@ -102,7 +102,7 @@ defmodule ExW3.Contract do
       Enum.map(events, fn {name, v} ->
         types = Enum.map(v["inputs"], &Map.get(&1, "type"))
         signature = Enum.join([name, "(", Enum.join(types, ","), ")"])
-        encoded_event_signature = ExW3.keccak256(signature)
+        encoded_event_signature = ExW3.Utils.keccak256(signature)
 
         indexed_fields =
           Enum.filter(v["inputs"], fn input ->

--- a/lib/exw3/normalize.ex
+++ b/lib/exw3/normalize.ex
@@ -1,0 +1,9 @@
+defmodule ExW3.Normalize do
+  @spec transform_to_integer(map(), list()) :: map()
+  def transform_to_integer(map, keys) do
+    for k <- keys, into: %{} do
+      {:ok, v} = map |> Map.get(k) |> ExW3.Utils.hex_to_integer()
+      {k, v}
+    end
+  end
+end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -115,4 +115,10 @@ defmodule ExW3.Utils do
 
     "0x" <> List.to_string(list_arr)
   end
+
+  @doc "Checks if the address is a valid checksummed address"
+  @spec is_valid_checksum_address(String.t()) :: boolean
+  def is_valid_checksum_address(address) do
+    ExW3.Utils.to_checksum_address(address) == address
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -86,4 +86,33 @@ defmodule ExW3.Utils do
       throw("#{key} not valid unit")
     end
   end
+
+  @doc "Returns a checksummed address conforming to EIP-55"
+  @spec to_checksum_address(String.t()) :: String.t()
+  def to_checksum_address(address) do
+    address = address |> String.downcase() |> String.replace(~r/^0x/, "")
+    {:ok, hash_bin} = ExKeccak.hash_256(address)
+
+    hash =
+      hash_bin
+      |> Base.encode16(case: :lower)
+      |> String.replace(~r/^0x/, "")
+
+    keccak_hash_list =
+      hash
+      |> String.split("", trim: true)
+      |> Enum.map(fn x -> elem(Integer.parse(x, 16), 0) end)
+
+    list_arr =
+      for n <- 0..(String.length(address) - 1) do
+        number = Enum.at(keccak_hash_list, n)
+
+        cond do
+          number >= 8 -> String.upcase(String.at(address, n))
+          true -> String.downcase(String.at(address, n))
+        end
+      end
+
+    "0x" <> List.to_string(list_arr)
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -36,4 +36,44 @@ defmodule ExW3.Utils do
     {:ok, hash} = ExKeccak.hash_256(string)
     "0x#{Base.encode16(hash, case: :lower)}"
   end
+
+  @unit_map %{
+    :noether => 0,
+    :wei => 1,
+    :kwei => 1_000,
+    :Kwei => 1_000,
+    :babbage => 1_000,
+    :femtoether => 1_000,
+    :mwei => 1_000_000,
+    :Mwei => 1_000_000,
+    :lovelace => 1_000_000,
+    :picoether => 1_000_000,
+    :gwei => 1_000_000_000,
+    :Gwei => 1_000_000_000,
+    :shannon => 1_000_000_000,
+    :nanoether => 1_000_000_000,
+    :nano => 1_000_000_000,
+    :szabo => 1_000_000_000_000,
+    :microether => 1_000_000_000_000,
+    :micro => 1_000_000_000_000,
+    :finney => 1_000_000_000_000_000,
+    :milliether => 1_000_000_000_000_000,
+    :milli => 1_000_000_000_000_000,
+    :ether => 1_000_000_000_000_000_000,
+    :kether => 1_000_000_000_000_000_000_000,
+    :grand => 1_000_000_000_000_000_000_000,
+    :mether => 1_000_000_000_000_000_000_000_000,
+    :gether => 1_000_000_000_000_000_000_000_000_000,
+    :tether => 1_000_000_000_000_000_000_000_000_000_000
+  }
+
+  @doc "Converts the value to whatever unit key is provided. See unit map for details."
+  @spec to_wei(integer, atom) :: integer
+  def to_wei(num, key) do
+    if @unit_map[key] do
+      num * @unit_map[key]
+    else
+      throw("#{key} not valid unit")
+    end
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -76,4 +76,14 @@ defmodule ExW3.Utils do
       throw("#{key} not valid unit")
     end
   end
+
+  @doc "Converts the value to whatever unit key is provided. See unit map for details."
+  @spec from_wei(integer, atom) :: integer | float | no_return
+  def from_wei(num, key) do
+    if @unit_map[key] do
+      num / @unit_map[key]
+    else
+      throw("#{key} not valid unit")
+    end
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -29,4 +29,11 @@ defmodule ExW3.Utils do
     ArgumentError ->
       {:error, :non_integer}
   end
+
+  @doc "Returns a 0x prepended 32 byte hash of the input string"
+  @spec keccak256(String.t()) :: String.t()
+  def keccak256(string) do
+    {:ok, hash} = ExKeccak.hash_256(string)
+    "0x#{Base.encode16(hash, case: :lower)}"
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -121,4 +121,13 @@ defmodule ExW3.Utils do
   def is_valid_checksum_address(address) do
     ExW3.Utils.to_checksum_address(address) == address
   end
+
+  @doc "converts Ethereum style bytes to string"
+  @spec bytes_to_string(binary()) :: binary()
+  def bytes_to_string(bytes) do
+    bytes
+    |> Base.encode16(case: :lower)
+    |> String.replace_trailing("0", "")
+    |> Base.decode16!(case: :lower)
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -130,4 +130,13 @@ defmodule ExW3.Utils do
     |> String.replace_trailing("0", "")
     |> Base.decode16!(case: :lower)
   end
+
+  @doc "Converts an Ethereum address into a form that can be used by the ABI encoder"
+  @spec format_address(binary()) :: integer()
+  def format_address(address) do
+    address
+    |> String.slice(2..-1)
+    |> Base.decode16!(case: :lower)
+    |> :binary.decode_unsigned()
+  end
 end

--- a/lib/exw3/utils.ex
+++ b/lib/exw3/utils.ex
@@ -139,4 +139,10 @@ defmodule ExW3.Utils do
     |> Base.decode16!(case: :lower)
     |> :binary.decode_unsigned()
   end
+
+  @doc "Converts bytes to Ethereum address"
+  @spec to_address(binary()) :: binary()
+  def to_address(bytes) do
+    Enum.join(["0x", bytes |> Base.encode16(case: :lower)], "")
+  end
 end

--- a/test/exw3/utils_test.exs
+++ b/test/exw3/utils_test.exs
@@ -147,4 +147,37 @@ defmodule ExW3.UtilsTest do
                "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"
     end
   end
+
+  describe ".is_valid_checksum_address/1" do
+    test "returns valid check for is_valid_checksum_address()" do
+      assert ExW3.Utils.is_valid_checksum_address("0x52908400098527886E0F7030069857D2E4169EE7") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0x27b1fdb04752bbc536007a920d24acb045561c26") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0xde709f2102306220921060314715629080e2fb77") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0x8617E340B3D01FA5F11F306F4090FD50E238070D") ==
+               true
+
+      assert ExW3.Utils.is_valid_checksum_address("0x52908400098527886E0F7030069857D2E4169EE7") ==
+               true
+    end
+
+    test "returns invalid check for is_valid_checksum_address()" do
+      assert ExW3.Utils.is_valid_checksum_address("0x2f015c60e0be116b1f0cd534704db9c92118fb6a") ==
+               false
+    end
+  end
 end

--- a/test/exw3/utils_test.exs
+++ b/test/exw3/utils_test.exs
@@ -32,4 +32,15 @@ defmodule ExW3.UtilsTest do
       assert ExW3.Utils.integer_to_hex(1.1) == {:error, :non_integer}
     end
   end
+
+  describe ".keccak256/1" do
+    test "returns a 0x prepended 32 byte hash of the input" do
+      hex_hash = ExW3.Utils.keccak256("foo")
+      assert "0x" <> hash = hex_hash
+      assert hash == "41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d"
+
+      num_bytes = byte_size(hash)
+      assert trunc(num_bytes / 2) == 32
+    end
+  end
 end

--- a/test/exw3/utils_test.exs
+++ b/test/exw3/utils_test.exs
@@ -82,4 +82,21 @@ defmodule ExW3.UtilsTest do
       assert Agent.get(agent, fn state -> state end)
     end
   end
+
+  describe ".from_wei/2" do
+    test "converts a unit from wei" do
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :wei) == 1_000_000_000_000_000_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :kwei) == 1_000_000_000_000_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :mwei) == 1_000_000_000_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :gwei) == 1_000_000_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :szabo) == 1_000_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :finney) == 1_000
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :ether) == 1
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :kether) == 0.001
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :grand) == 0.001
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :mether) == 0.000001
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :gether) == 0.000000001
+      assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :tether) == 0.000000000001
+    end
+  end
 end

--- a/test/exw3/utils_test.exs
+++ b/test/exw3/utils_test.exs
@@ -43,4 +43,43 @@ defmodule ExW3.UtilsTest do
       assert trunc(num_bytes / 2) == 32
     end
   end
+
+  describe ".to_wei/2" do
+    test "converts a unit to_wei" do
+      assert ExW3.Utils.to_wei(1, :wei) == 1
+      assert ExW3.Utils.to_wei(1, :kwei) == 1_000
+      assert ExW3.Utils.to_wei(1, :Kwei) == 1_000
+      assert ExW3.Utils.to_wei(1, :babbage) == 1_000
+      assert ExW3.Utils.to_wei(1, :mwei) == 1_000_000
+      assert ExW3.Utils.to_wei(1, :Mwei) == 1_000_000
+      assert ExW3.Utils.to_wei(1, :lovelace) == 1_000_000
+      assert ExW3.Utils.to_wei(1, :gwei) == 1_000_000_000
+      assert ExW3.Utils.to_wei(1, :Gwei) == 1_000_000_000
+      assert ExW3.Utils.to_wei(1, :shannon) == 1_000_000_000
+      assert ExW3.Utils.to_wei(1, :szabo) == 1_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :finney) == 1_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :ether) == 1_000_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :kether) == 1_000_000_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :grand) == 1_000_000_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :mether) == 1_000_000_000_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :gether) == 1_000_000_000_000_000_000_000_000_000
+      assert ExW3.Utils.to_wei(1, :tether) == 1_000_000_000_000_000_000_000_000_000_000
+
+      assert ExW3.Utils.to_wei(1, :kwei) == ExW3.Utils.to_wei(1, :femtoether)
+      assert ExW3.Utils.to_wei(1, :szabo) == ExW3.Utils.to_wei(1, :microether)
+      assert ExW3.Utils.to_wei(1, :finney) == ExW3.Utils.to_wei(1, :milliether)
+      assert ExW3.Utils.to_wei(1, :milli) == ExW3.Utils.to_wei(1, :milliether)
+      assert ExW3.Utils.to_wei(1, :milli) == ExW3.Utils.to_wei(1000, :micro)
+
+      {:ok, agent} = Agent.start_link(fn -> false end)
+
+      try do
+        ExW3.Utils.to_wei(1, :wei1)
+      catch
+        _ -> Agent.update(agent, fn _ -> true end)
+      end
+
+      assert Agent.get(agent, fn state -> state end)
+    end
+  end
 end

--- a/test/exw3/utils_test.exs
+++ b/test/exw3/utils_test.exs
@@ -99,4 +99,52 @@ defmodule ExW3.UtilsTest do
       assert ExW3.Utils.from_wei(1_000_000_000_000_000_000, :tether) == 0.000000000001
     end
   end
+
+  describe ".to_checksum_address/1" do
+    test "returns checksum for all caps address" do
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0x52908400098527886E0F7030069857D2E4169EE7")
+             ) ==
+               "0x52908400098527886E0F7030069857D2E4169EE7"
+
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0x8617E340B3D01FA5F11F306F4090FD50E238070D")
+             ) ==
+               "0x8617E340B3D01FA5F11F306F4090FD50E238070D"
+    end
+
+    test "returns checksumfor all lowercase address" do
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0xde709f2102306220921060314715629080e2fb77")
+             ) ==
+               "0xde709f2102306220921060314715629080e2fb77"
+
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0x27b1fdb04752bbc536007a920d24acb045561c26")
+             ) ==
+               "0x27b1fdb04752bbc536007a920d24acb045561c26"
+    end
+
+    test "returns checksum for normal addresses" do
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
+             ) ==
+               "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359")
+             ) ==
+               "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB")
+             ) ==
+               "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"
+
+      assert ExW3.Utils.to_checksum_address(
+               String.downcase("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb")
+             ) ==
+               "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"
+    end
+  end
 end

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -461,21 +461,6 @@ defmodule ExW3Test do
              ExW3.Contract.send(:SimpleStorage, :set, [1], %{from: Enum.at(context[:accounts], 0)})
   end
 
-  test "unit conversion from wei" do
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :wei) == 1_000_000_000_000_000_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :kwei) == 1_000_000_000_000_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :mwei) == 1_000_000_000_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :gwei) == 1_000_000_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :szabo) == 1_000_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :finney) == 1_000
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :ether) == 1
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :kether) == 0.001
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :grand) == 0.001
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :mether) == 0.000001
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :gether) == 0.000000001
-    assert ExW3.from_wei(1_000_000_000_000_000_000, :tether) == 0.000000000001
-  end
-
   test ".get_logs/1", context do
     ExW3.Contract.register(:EventTester, abi: context[:event_tester_abi])
 

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -351,36 +351,6 @@ defmodule ExW3Test do
     assert ExW3.to_address(same_address) == Enum.at(context[:accounts], 0)
   end
 
-  test "returns checksum for all caps address" do
-    assert ExW3.to_checksum_address(String.downcase("0x52908400098527886E0F7030069857D2E4169EE7")) ==
-             "0x52908400098527886E0F7030069857D2E4169EE7"
-
-    assert ExW3.to_checksum_address(String.downcase("0x8617E340B3D01FA5F11F306F4090FD50E238070D")) ==
-             "0x8617E340B3D01FA5F11F306F4090FD50E238070D"
-  end
-
-  test "returns checksumfor all lowercase address" do
-    assert ExW3.to_checksum_address(String.downcase("0xde709f2102306220921060314715629080e2fb77")) ==
-             "0xde709f2102306220921060314715629080e2fb77"
-
-    assert ExW3.to_checksum_address(String.downcase("0x27b1fdb04752bbc536007a920d24acb045561c26")) ==
-             "0x27b1fdb04752bbc536007a920d24acb045561c26"
-  end
-
-  test "returns checksum for normal addresses" do
-    assert ExW3.to_checksum_address(String.downcase("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")) ==
-             "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
-
-    assert ExW3.to_checksum_address(String.downcase("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359")) ==
-             "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
-
-    assert ExW3.to_checksum_address(String.downcase("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB")) ==
-             "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"
-
-    assert ExW3.to_checksum_address(String.downcase("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb")) ==
-             "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"
-  end
-
   test "returns valid check for is_valid_checksum_address()" do
     assert ExW3.is_valid_checksum_address("0x52908400098527886E0F7030069857D2E4169EE7") == true
     assert ExW3.is_valid_checksum_address("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB") == true

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -461,43 +461,6 @@ defmodule ExW3Test do
              ExW3.Contract.send(:SimpleStorage, :set, [1], %{from: Enum.at(context[:accounts], 0)})
   end
 
-  test "unit conversion to_wei" do
-    assert ExW3.to_wei(1, :wei) == 1
-    assert ExW3.to_wei(1, :kwei) == 1_000
-    assert ExW3.to_wei(1, :Kwei) == 1_000
-    assert ExW3.to_wei(1, :babbage) == 1_000
-    assert ExW3.to_wei(1, :mwei) == 1_000_000
-    assert ExW3.to_wei(1, :Mwei) == 1_000_000
-    assert ExW3.to_wei(1, :lovelace) == 1_000_000
-    assert ExW3.to_wei(1, :gwei) == 1_000_000_000
-    assert ExW3.to_wei(1, :Gwei) == 1_000_000_000
-    assert ExW3.to_wei(1, :shannon) == 1_000_000_000
-    assert ExW3.to_wei(1, :szabo) == 1_000_000_000_000
-    assert ExW3.to_wei(1, :finney) == 1_000_000_000_000_000
-    assert ExW3.to_wei(1, :ether) == 1_000_000_000_000_000_000
-    assert ExW3.to_wei(1, :kether) == 1_000_000_000_000_000_000_000
-    assert ExW3.to_wei(1, :grand) == 1_000_000_000_000_000_000_000
-    assert ExW3.to_wei(1, :mether) == 1_000_000_000_000_000_000_000_000
-    assert ExW3.to_wei(1, :gether) == 1_000_000_000_000_000_000_000_000_000
-    assert ExW3.to_wei(1, :tether) == 1_000_000_000_000_000_000_000_000_000_000
-
-    assert ExW3.to_wei(1, :kwei) == ExW3.to_wei(1, :femtoether)
-    assert ExW3.to_wei(1, :szabo) == ExW3.to_wei(1, :microether)
-    assert ExW3.to_wei(1, :finney) == ExW3.to_wei(1, :milliether)
-    assert ExW3.to_wei(1, :milli) == ExW3.to_wei(1, :milliether)
-    assert ExW3.to_wei(1, :milli) == ExW3.to_wei(1000, :micro)
-
-    {:ok, agent} = Agent.start_link(fn -> false end)
-
-    try do
-      ExW3.to_wei(1, :wei1)
-    catch
-      _ -> Agent.update(agent, fn _ -> true end)
-    end
-
-    assert Agent.get(agent, fn state -> state end)
-  end
-
   test "unit conversion from wei" do
     assert ExW3.from_wei(1_000_000_000_000_000_000, :wei) == 1_000_000_000_000_000_000
     assert ExW3.from_wei(1_000_000_000_000_000_000, :kwei) == 1_000_000_000_000_000

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -351,21 +351,6 @@ defmodule ExW3Test do
     assert ExW3.to_address(same_address) == Enum.at(context[:accounts], 0)
   end
 
-  test "returns valid check for is_valid_checksum_address()" do
-    assert ExW3.is_valid_checksum_address("0x52908400098527886E0F7030069857D2E4169EE7") == true
-    assert ExW3.is_valid_checksum_address("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB") == true
-    assert ExW3.is_valid_checksum_address("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb") == true
-    assert ExW3.is_valid_checksum_address("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed") == true
-    assert ExW3.is_valid_checksum_address("0x27b1fdb04752bbc536007a920d24acb045561c26") == true
-    assert ExW3.is_valid_checksum_address("0xde709f2102306220921060314715629080e2fb77") == true
-    assert ExW3.is_valid_checksum_address("0x8617E340B3D01FA5F11F306F4090FD50E238070D") == true
-    assert ExW3.is_valid_checksum_address("0x52908400098527886E0F7030069857D2E4169EE7") == true
-  end
-
-  test "returns invalid check for is_valid_checksum_address()" do
-    assert ExW3.is_valid_checksum_address("0x2f015c60e0be116b1f0cd534704db9c92118fb6a") == false
-  end
-
   test "returns proper error messages at contract deployment", context do
     ExW3.Contract.register(:SimpleStorage, abi: context[:simple_storage_abi])
 

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -1,4 +1,4 @@
-defmodule EXW3Test do
+defmodule ExW3Test do
   use ExUnit.Case
   doctest ExW3
 
@@ -44,20 +44,6 @@ defmodule EXW3Test do
   #   ExW3.mine(5)
   #   assert ExW3.block_number() == block_number + 5
   # end
-
-  test "keccak256 hash some data" do
-    hash = ExW3.keccak256("foo")
-    assert String.slice(hash, 0..1) == "0x"
-
-    assert hash == "0x41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d"
-
-    num_bytes =
-      hash
-      |> String.slice(2..-1)
-      |> byte_size
-
-    assert trunc(num_bytes / 2) == 32
-  end
 
   test "starts a Contract GenServer for simple storage contract", context do
     ExW3.Contract.register(:SimpleStorage, abi: context[:simple_storage_abi])
@@ -559,7 +545,7 @@ defmodule EXW3Test do
     filter = %{
       fromBlock: from_block,
       toBlock: "latest",
-      topics: [ExW3.keccak256("Simple(uint256,bytes32)")]
+      topics: [ExW3.Utils.keccak256("Simple(uint256,bytes32)")]
     }
 
     assert {:ok, logs} = ExW3.get_logs(filter)

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -136,7 +136,7 @@ defmodule ExW3Test do
       logs
       |> Enum.at(0)
       |> Map.get("data")
-      |> ExW3.bytes_to_string()
+      |> ExW3.Utils.bytes_to_string()
 
     assert data == "Hello, World!"
 
@@ -166,7 +166,7 @@ defmodule ExW3Test do
       logs
       |> Enum.at(0)
       |> Map.get("data")
-      |> ExW3.bytes_to_string()
+      |> ExW3.Utils.bytes_to_string()
 
     assert data == "Hello, World!"
   end
@@ -206,7 +206,7 @@ defmodule ExW3Test do
     log_data = Map.get(event_log, "data")
     assert log_data |> is_map
     assert Map.get(log_data, "num") == 42
-    assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
+    assert ExW3.Utils.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
 
     ExW3.Contract.uninstall_filter(filter_id)
 
@@ -230,7 +230,7 @@ defmodule ExW3Test do
     log_data = Map.get(event_log, "data")
     assert log_data |> is_map
     assert Map.get(log_data, "num") == 46
-    assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
+    assert ExW3.Utils.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
     ExW3.Contract.uninstall_filter(indexed_filter_id)
 
@@ -262,7 +262,7 @@ defmodule ExW3Test do
     log_data = Map.get(event_log, "data")
     assert log_data |> is_map
     assert Map.get(log_data, "num") == 46
-    assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
+    assert ExW3.Utils.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
 
     ExW3.Contract.uninstall_filter(indexed_filter_id)
@@ -294,7 +294,7 @@ defmodule ExW3Test do
     log_data = Map.get(event_log, "data")
     assert log_data |> is_map
     assert Map.get(log_data, "num") == 46
-    assert ExW3.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
+    assert ExW3.Utils.bytes_to_string(Map.get(log_data, "data")) == "Hello, World!"
     assert Map.get(log_data, "otherNum") == 42
 
     ExW3.Contract.uninstall_filter(indexed_filter_id)
@@ -322,7 +322,7 @@ defmodule ExW3Test do
 
     assert foo == 42
 
-    assert ExW3.bytes_to_string(foobar) == "Hello, world!"
+    assert ExW3.Utils.bytes_to_string(foobar) == "Hello, world!"
   end
 
   test "starts a Contract GenServer for AddressTester contract", context do

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -344,7 +344,7 @@ defmodule ExW3Test do
 
     formatted_address =
       Enum.at(context[:accounts], 0)
-      |> ExW3.format_address()
+      |> ExW3.Utils.format_address()
 
     {:ok, same_address} = ExW3.Contract.call(:AddressTester, :get, [formatted_address])
 

--- a/test/exw3_test.exs
+++ b/test/exw3_test.exs
@@ -348,7 +348,7 @@ defmodule ExW3Test do
 
     {:ok, same_address} = ExW3.Contract.call(:AddressTester, :get, [formatted_address])
 
-    assert ExW3.to_address(same_address) == Enum.at(context[:accounts], 0)
+    assert ExW3.Utils.to_address(same_address) == Enum.at(context[:accounts], 0)
   end
 
   test "returns proper error messages at contract deployment", context do


### PR DESCRIPTION
Step 2 of a refactor to turn the `ExW3` module into a facade 

- `ExW3.Utils`
- `ExW3.Normalize`