### PR TITLE
Contract.get_logs function

### DIFF
--- a/test/exw3/client_test.exs
+++ b/test/exw3/client_test.exs
@@ -9,7 +9,7 @@ defmodule ExW3.ClientTest do
   test ".call_client/2 calls the JSON-RPC method with the given arguments" do
     assert {:ok, accounts} = ExW3.Client.call_client(:eth_accounts)
     assert Enum.count(accounts) > 0
-    assert ["0x" <> _ = account] = accounts
+    assert ["0x" <> _ = account | _] = accounts
 
     assert {:ok, balance} = ExW3.Client.call_client(:eth_get_balance, [account])
     assert "0x" <> _ = balance


### PR DESCRIPTION
`ExW3.Contract.get_logs` function to get formatted logs between blocks for a given "contract".

# Need
The get_filter_changes is useful but has 2 problems (at least for me):
1- The query doesn't return logs between 2 given block numbers, just the "new" (like the name specify =) )
2- After a few manual tests, the filter_id disappear after a minute or so without quering. If the supervisor die for some reason you can't get the "missing changes" You have to create a new filter id and start from "now".

To work around these 2  issues, I prefer directly ask for a block range and process the returned logs, then ask again from where I left.

If anything can be improved let me know =) 
I'll let a few comments in the PR to let you know why I had to make changes.

# Manually tested on Polygon
```elixir
ExW3.Contract.register(:DAI, abi: ExW3.Abi.load_abi("./dai.abi")) # only with Transfer event
ExW3.Contract.at(:DAI, "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063")
{:ok, logs} = ExW3.Contract.get_logs(:DAI, %{fromBlock:  21986395, toBlock: 21986397}) # logs are properly formatted
```